### PR TITLE
Update Faultdomains value

### DIFF
--- a/deployment-artifacts-standalone-vm/azuredeploy.json
+++ b/deployment-artifacts-standalone-vm/azuredeploy.json
@@ -311,7 +311,7 @@
 			"dependsOn": [],
 			"properties": {
 				"platformUpdateDomainCount": 5,
-				"platformFaultDomainCount": 3
+				"platformFaultDomainCount": 2
 			},
 			"sku": {
 				"name": "Aligned"


### PR DESCRIPTION
The majority of regions in Azure do not currently support 3 fault domains for Availability sets. Recommend default here is 2 so that deployments do not fail in those regions.